### PR TITLE
Updated jquery.stickytabs.js

### DIFF
--- a/jquery.stickytabs.js
+++ b/jquery.stickytabs.js
@@ -20,9 +20,7 @@
 
         // Set the correct tab when a user uses their back/forward button
         //(jQuery will implement the correct event handler per browser)
-        $(window).on('hashchange'), function(){
-        	showTabFromHash;
-        }
+        $(window).on('hashchange', showTabFromHash);
         
         //window.addEventListener('hashchange', showTabFromHash, false);
 
@@ -36,7 +34,7 @@
 			else {
 				var href = this.href;
 				var hash = href.substring(href.indexOf('#'));
-				location.hash = hash;
+				window.location.hash = hash;
 			}		
                   	
 		

--- a/jquery.stickytabs.js
+++ b/jquery.stickytabs.js
@@ -19,14 +19,31 @@
         showTabFromHash(context)
 
         // Set the correct tab when a user uses their back/forward button
-        window.addEventListener('hashchange', showTabFromHash, false);
+        //(jQuery will implement the correct event handler per browser)
+        $(window).on('hashchange'), function(){
+        	showTabFromHash;
+        }
+        
+        //window.addEventListener('hashchange', showTabFromHash, false);
 
         // Change the URL when tabs are clicked
         $('a', context).on('click', function(e) {
-          history.pushState(null, null, this.href);
-        });
+		
+			// fall-back to hash update if pushState isn't supported by browser (e.g. IE8).
+			if(history.pushState) {
+				history.pushState(null, null, this.href);
+			}
+			else {
+				var href = this.href;
+				var hash = href.substring(href.indexOf('#'));
+				location.hash = hash;
+			}		
+                  	
+		
+		});
 
         return this;
     };
 }( jQuery ));
+
 


### PR DESCRIPTION
I had a need to support IE8 which doesn't support the _hashchange_ event or _history.pushState_. I just added a fall-back for both.
