### PR TITLE
Change the hash on the fly (callback)

### DIFF
--- a/jquery.stickytabs.js
+++ b/jquery.stickytabs.js
@@ -32,7 +32,13 @@
         $('a', context).on('click', function(e) {
             href=this.href;
             if($.fn.stickyTabs.URLcallback) href=$.fn.stickyTabs.URLcallback(this.href)
-            history.pushState(null, null, href);
+            //history.pushState(null, null, href);
+            
+          parts=href.split("#")
+          parts.shift()
+          if(parts.length)
+          window.location.hash="#"+parts.join('#')
+          
         });
 
         return this;

--- a/jquery.stickytabs.js
+++ b/jquery.stickytabs.js
@@ -4,6 +4,13 @@
  * @author Aidan Lister <aidan@php.net>
  * @version 1.0.1
  */
+ 
+ //added a global: URLcallback
+ //allows to change the url before sending to pushstate 
+ //if set, we can do this: correct an url like "http://host/evalv3#logs" to "http://host/evalv3#/logs"
+ //$.fn.stickyTabs.URLcallback=function(location){ return location.search('#/')==-1?location.replace(/#/, '#/'):location; }
+ //needed to work with a router like flatiron director
+
 (function ( $ ) {
     $.fn.stickyTabs = function() {
         context = this
@@ -23,7 +30,9 @@
 
         // Change the URL when tabs are clicked
         $('a', context).on('click', function(e) {
-          history.pushState(null, null, this.href);
+            href=this.href;
+            if($.fn.stickyTabs.URLcallback) href=$.fn.stickyTabs.URLcallback(this.href)
+            history.pushState(null, null, href);
         });
 
         return this;


### PR DESCRIPTION
added a global: URLcallback
*_allows to change the url before sending to pushstate *_
if set, we can do this: correct an url like "http://host/evalv3#logs" to "http://host/evalv3#/logs"
$.fn.stickyTabs.URLcallback=function(location){ return location.search('#/')==-1?location.replace(/#/, '#/'):location; }
needed to work with a router like flatiron director
